### PR TITLE
Change production config to encode duration as nanos

### DIFF
--- a/zapgcp.go
+++ b/zapgcp.go
@@ -47,7 +47,7 @@ func (cfg *Config) ToZapConfig() (zap.Config, []zap.Option) {
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    encodeLevel,
 			EncodeTime:     zapcore.RFC3339TimeEncoder,
-			EncodeDuration: zapcore.MillisDurationEncoder,
+			EncodeDuration: zapcore.NanosDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		},
 		OutputPaths:      []string{"stdout"},

--- a/zapgcp_test.go
+++ b/zapgcp_test.go
@@ -61,7 +61,7 @@ func TestProductionConfig(t *testing.T) {
 	logger.DPanic("testing dpanic", zap.Duration("time_til_implosion", 3*time.Millisecond), zap.Error(errors.New("divided by zero successfully")))
 
 	// DPanic should include a stacktrace, which will be machine-specific. So we just do a string match on the prefix.
-	wantPrefix := `{"severity":"CRITICAL","time":"1970-01-01T00:00:05Z","message":"testing dpanic","time_til_implosion":3,"error":"divided by zero successfully","stacktrace":"github.com/Silicon-Ally/zapgcp.TestProductionConfig`
+	wantPrefix := `{"severity":"CRITICAL","time":"1970-01-01T00:00:05Z","message":"testing dpanic","time_til_implosion":3000000,"error":"divided by zero successfully","stacktrace":"github.com/Silicon-Ally/zapgcp.TestProductionConfig`
 	lines := writer.Lines()
 	gotLine := lines[len(lines)-1]
 


### PR DESCRIPTION
Some operations take less than a millisecond, and they show up as `0`, which isn't great.
